### PR TITLE
お知らせに大宮祭を追加。筑波大学コラボの文を修正。

### DIFF
--- a/src/json/notices.json
+++ b/src/json/notices.json
@@ -1,8 +1,12 @@
 [
     {
         "date": "2021/9/28",
-        "text": "筑波大のTsukuba DTM Lab. (TDL)サークルとのコラボアルバムをリリースしました。",
+        "text": "筑波大学の作曲サークル「Tsukuba DTM Lab.(TDL.)」さんとのコラボEPをリリースしました。",
         "url": "https://tsukubadtm.bandcamp.com/album/tdl-x-digicre-dual-tornado"
+    },
+    {
+        "date": "2021/5/23",
+        "text": "第25回大宮祭に参加しました。clusterにて作品展示のイベント会場を設営しました。"
     },
     {
         "date": "2021/3/1",


### PR DESCRIPTION
お知らせに、2021年5月に行われた大宮祭について追加しました。
また、筑波大学TDL.さんとのコラボEPについて文の修正を行いました。